### PR TITLE
Save and restore affected_rows after issuing EXPLAIN query

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
     ruby-progressbar (1.10.0)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
@@ -67,6 +68,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop
+  sqlite3
 
 BUNDLED WITH
    2.1.4

--- a/activerecord-explainer.gemspec
+++ b/activerecord-explainer.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'sqlite3'
 end

--- a/lib/activerecord/explainer/subscriber.rb
+++ b/lib/activerecord/explainer/subscriber.rb
@@ -7,7 +7,12 @@ module ActiveRecord
         payload = event.payload
         return if ignore_payload?(payload) || !ActiveRecord::Base.connection.supports_explain?
 
+        # Save `affected_rows` and restore after issuing EXPLAIN query because
+        # the query will resets `affected_rows` to 0.
+        original_affectet_rows = affected_rows
         debug exec_explain(sql: payload[:sql], binds: payload[:binds])
+      ensure
+        affectet_rows = original_affectet_rows
       end
 
       private

--- a/spec/activerecord/explainer/subscriber_spec.rb
+++ b/spec/activerecord/explainer/subscriber_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'activerecord/explainer/subscriber'
+
+RSpec.describe ActiveRecord::Explainer::Subscriber do
+  before(:context) do
+    ActiveRecord::Explainer.config.logger = Logger.new(File::NULL)
+    ActiveRecord::Explainer::Subscriber.attach_to(:active_record)
+  end
+
+  context 'When a model using optimistic locking' do
+    let(:user) { User.create!(username: 'John') }
+
+    it 'should not reset affected_rows' do
+      expect { user.update!(username: 'Jane') }.not_to raise_error
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,24 @@
 require 'bundler/setup'
 require 'activerecord-explainer'
 
+ActiveRecord::Base.configurations = { 'test' => { 'adapter' => 'sqlite3', 'database' => ':memory:' } }
+ActiveRecord::Base.establish_connection(:test)
+
+class User < ActiveRecord::Base; end
+
+class CreateUsers < ActiveRecord::Migration[5.1]
+  def self.up
+    create_table :users do |t|
+      t.string :username
+      t.integer :lock_version, default: 0
+    end
+  end
+end
+
+ActiveRecord::Migration.suppress_messages do
+  CreateUsers.up
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
Fixes #2